### PR TITLE
Only stub crypto if it's not globally available

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -9,7 +9,9 @@ import {
   getDeleteProfileEventArgs,
 } from '.'
 
-vi.stubGlobal('crypto', crypto)
+if (!global.crypto) {
+  vi.stubGlobal('crypto', crypto)
+}
 
 const settings = {
   token: '12345',


### PR DESCRIPTION
Tests were failing on node 20 due to lack of that check
